### PR TITLE
ADD: two functions added: init(), die(), and minor improvements

### DIFF
--- a/gen_cert.sh
+++ b/gen_cert.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+## 
+# Change the name of the cert/key file if needed
+##
+CERT='certfile.cert'
+KEY='keyfile.key'
+
+openssl req -x509 \
+            -nodes \
+            -newkey rsa:4096 \
+            -keyout $KEY \
+            -out $CERT \
+            -days 3650


### PR DESCRIPTION
this adds argument parsing (init()) as well as a error handling function (die()). Also, a shellscript is provided to generate a key/cert pair if HTTPS is to be used.
The functionality is the same as before. These are mostly small improvements.

Tested on Debian 11 (Bullseye) amd64.